### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module returns for an given OS the Azure Image as well as its default user 
 ```hcl
 module "dcos-tested-oses" {
   source  = "terraform-dcos/tested-oses/azurerm"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   os = "centos_7.3"
 }

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  * ```hcl
  * module "dcos-tested-oses" {
  *   source  = "terraform-dcos/tested-oses/azurerm"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   os = "centos_7.3"
  * }


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2